### PR TITLE
Fix typo in metadata for About/projects

### DIFF
--- a/about/projects.mdx
+++ b/about/projects.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-description: "A list of all my past a current projects, both professional and personal."
+description: "A list of all my past and current projects, both professional and personal."
 ---
 
 import OpenDIReactDecisionEngine from './assets/Authoring_Tool_April_2025.gif';


### PR DESCRIPTION
"past a current projects" --> "past and current projects"