### PR TITLE
Gallery style bugfix

### DIFF
--- a/gallery/index.css
+++ b/gallery/index.css
@@ -19,8 +19,3 @@
     color: black;
 }
 
-@media screen and (max-width: 996px) {
-    .gallery-tile {
-        width: 95% !important;
-    }
-}


### PR DESCRIPTION
Related to gallery component commit https://github.com/IAmKelDev/keldev-gallery-component/commit/c93a2d93d4e646e8ccb8b313daa0566611d8eb3b  
Gallery tile width is now calculated up front so the screen size based style rule is no longer necessary. Seems to have been causing mobile display issues, so hopefully those will be fixed now.