### PR TITLE
Add "Thoughts" secondary customized blog

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "src/external/gallery"]
 	path = src/external/gallery
 	url = git@github.com:IAmKelDev/keldev-gallery-component.git
+[submodule "thoughts"]
+	path = thoughts
+	url = git@github.com:IAmKelDev/keldev-thoughts-drafts.git

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -130,7 +130,7 @@ const config: Config = {
       {
         // https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-blog#ex-config
         id: 'blog',
-        blogDescription: 'Technical posts about software development. Thoughts about media, games, life, miscellanea.',
+        blogDescription: 'Technical posts about software development. Thoughts about media. For looser, more frequent posts check my Thoughts page.',
         routeBasePath: 'blog',
         path: './blog',
         showReadingTime: true,
@@ -153,7 +153,7 @@ const config: Config = {
       {
         id: 'thoughts',
         blogTitle: 'Thoughts',
-        blogDescription: 'Random thoughts, lower-effort higher-frequency less-polished bloggy posts, reshares of my stuff from elsewhere, stuff like that. For higher-effort posts, see my actual blog.',
+        blogDescription: 'Lower-effort, higher-frequency, less-polished bloggy posts, about a wider variety of topics. For higher-effort posts, see my actual Blog.',
         routeBasePath: 'thoughts',
         blogSidebarCount: 0,
         postsPerPage: 50,

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -80,6 +80,11 @@ const config: Config = {
           position: 'left'
         },
         {
+          to: '/thoughts',
+          label: 'Thoughts',
+          position: 'left'
+        },
+        {
           href: 'https://github.com/IAmKelDev',
           label: 'GitHub',
           position: 'right',
@@ -124,6 +129,7 @@ const config: Config = {
       '@docusaurus/plugin-content-blog',
       {
         // https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-blog#ex-config
+        id: 'blog',
         blogDescription: 'Technical posts about software development. Thoughts about media, games, life, miscellanea.',
         routeBasePath: 'blog',
         path: './blog',
@@ -141,6 +147,24 @@ const config: Config = {
         onInlineAuthors: 'warn',
         onUntruncatedBlogPosts: 'warn',
       },
+    ],
+    [
+      '@docusaurus/plugin-content-blog',
+      {
+        id: 'thoughts',
+        blogTitle: 'Thoughts',
+        blogDescription: 'Random thoughts, lower-effort higher-frequency less-polished bloggy posts, reshares of my stuff from elsewhere, stuff like that. For higher-effort posts, see my actual blog.',
+        routeBasePath: 'thoughts',
+        blogSidebarCount: 0,
+        postsPerPage: 50,
+        path: './thoughts',
+        showReadingTime: false,
+        onUntruncatedBlogPosts: 'ignore',
+        feedOptions: {
+          type: ['rss', 'atom'],
+          xslt: true,
+        }
+      }
     ],
     [
       '@docusaurus/plugin-content-docs',

--- a/src/theme/BlogListPage/index.tsx
+++ b/src/theme/BlogListPage/index.tsx
@@ -1,0 +1,58 @@
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import {
+  PageMetadata,
+  HtmlClassNameProvider,
+  ThemeClassNames,
+} from '@docusaurus/theme-common';
+import BlogLayout from '@theme/BlogLayout';
+import BlogListPaginator from '@theme/BlogListPaginator';
+import SearchMetadata from '@theme/SearchMetadata';
+import type {Props} from '@theme/BlogListPage';
+import BlogPostItems from '@theme/BlogPostItems';
+import BlogListPageStructuredData from '@theme/BlogListPage/StructuredData';
+import styles from './styles.module.css'
+
+function BlogListPageMetadata(props: Props): ReactNode {
+  const {metadata} = props;
+  const {
+    siteConfig: {title: siteTitle},
+  } = useDocusaurusContext();
+  const {blogDescription, blogTitle, permalink} = metadata;
+  const isBlogOnlyMode = permalink === '/';
+  const title = isBlogOnlyMode ? siteTitle : blogTitle;
+  return (
+    <>
+      <PageMetadata title={title} description={blogDescription} />
+      <SearchMetadata tag="blog_posts_list" />
+    </>
+  );
+}
+
+function BlogListPageContent(props: Props): ReactNode {
+  const {metadata, items, sidebar} = props;
+  const {blogDescription, page} = metadata;
+  return (
+    <BlogLayout sidebar={sidebar}>
+      {page === 1 && <p className={styles.blogDescription}>{blogDescription}</p>}
+      <BlogPostItems items={items} />
+      <BlogListPaginator metadata={metadata} />
+    </BlogLayout>
+  );
+}
+
+export default function BlogListPage(props: Props): ReactNode {
+  return (
+    <HtmlClassNameProvider
+      className={clsx(
+        ThemeClassNames.wrapper.blogPages,
+        ThemeClassNames.page.blogListPage,
+      )}>
+      <BlogListPageMetadata {...props} />
+      <BlogListPageStructuredData {...props} />
+      <BlogListPageContent {...props} />
+    </HtmlClassNameProvider>
+  );
+}

--- a/src/theme/BlogListPage/styles.module.css
+++ b/src/theme/BlogListPage/styles.module.css
@@ -1,0 +1,3 @@
+.blogDescription {
+    padding-bottom: 2rem;
+}

--- a/src/theme/BlogPostItem/Container/index.tsx
+++ b/src/theme/BlogPostItem/Container/index.tsx
@@ -1,0 +1,22 @@
+import React, {type ReactNode} from 'react';
+import Container from '@theme-original/BlogPostItem/Container';
+import type ContainerType from '@theme/BlogPostItem/Container';
+import type {WrapperProps} from '@docusaurus/types';
+import { useBlogPost } from '@docusaurus/plugin-content-blog/client'
+import styles from './styles.module.css';
+import clsx from 'clsx';
+
+type Props = WrapperProps<typeof ContainerType>;
+
+export default function ContainerWrapper(props: Props): ReactNode {
+  const {metadata} = useBlogPost();
+  const isThought = metadata.permalink.startsWith('/thoughts');
+  return (
+    <>
+      <Container
+        {...props}
+        className={clsx(props.className, isThought && styles.thoughtContainer)}
+      />
+    </>
+  );
+}

--- a/src/theme/BlogPostItem/Container/styles.module.css
+++ b/src/theme/BlogPostItem/Container/styles.module.css
@@ -1,0 +1,16 @@
+.thoughtContainer {
+    background: var(--ifm-color-emphasis-100);
+    padding: 1rem 1.5rem 0.5rem;
+    border-radius: 1rem;
+    border: 0.15rem var(--ifm-color-emphasis-400) solid;
+    display: inline-block;
+}
+
+.thoughtContainer :global(.markdown) {
+    font-size: 0.9rem;
+}
+
+.thoughtContainer :global(.zoomable) img {
+    max-height: 25rem;
+    width: auto;
+}

--- a/src/theme/BlogPostItem/Container/styles.module.css
+++ b/src/theme/BlogPostItem/Container/styles.module.css
@@ -14,3 +14,7 @@
     max-height: 25rem;
     width: auto;
 }
+
+.thoughtContainer :global(footer.docusaurus-mt-lg) {
+    margin-top: 0.5rem;
+}

--- a/src/theme/BlogPostItem/Footer/index.tsx
+++ b/src/theme/BlogPostItem/Footer/index.tsx
@@ -1,0 +1,20 @@
+import React, {type ReactNode} from 'react';
+import Footer from '@theme-original/BlogPostItem/Footer';
+import type FooterType from '@theme/BlogPostItem/Footer';
+import type {WrapperProps} from '@docusaurus/types';
+import { useBlogPost } from '@docusaurus/plugin-content-blog/client';
+import BlogPostItemHeaderInfo from '@theme/BlogPostItem/Header/Info';
+import styles from './styles.module.css';
+
+type Props = WrapperProps<typeof FooterType>;
+
+export default function FooterWrapper(props: Props): ReactNode {
+  const {metadata} = useBlogPost();
+  const isThought = metadata.permalink.startsWith('/thoughts');
+  return (
+    <>
+      {isThought && <BlogPostItemHeaderInfo className={styles.infoInFooter}/>}
+      <Footer {...props} />
+    </>
+  );
+}

--- a/src/theme/BlogPostItem/Footer/styles.module.css
+++ b/src/theme/BlogPostItem/Footer/styles.module.css
@@ -1,6 +1,8 @@
 .infoInFooter {
     margin: 0.1rem !important;
+    margin-top: 0.3rem !important;
     font-style: italic;
     font-weight: normal;
     font-size: 0.85rem;
+    border-top: 0.1rem var(--ifm-color-emphasis-400) solid;
 }

--- a/src/theme/BlogPostItem/Footer/styles.module.css
+++ b/src/theme/BlogPostItem/Footer/styles.module.css
@@ -1,0 +1,6 @@
+.infoInFooter {
+    margin: 0.1rem !important;
+    font-style: italic;
+    font-weight: normal;
+    font-size: 0.85rem;
+}

--- a/src/theme/BlogPostItem/Header/Info/index.tsx
+++ b/src/theme/BlogPostItem/Header/Info/index.tsx
@@ -1,0 +1,87 @@
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import {translate} from '@docusaurus/Translate';
+import {usePluralForm} from '@docusaurus/theme-common';
+import {useDateTimeFormat} from '@docusaurus/theme-common/internal';
+import {useBlogPost} from '@docusaurus/plugin-content-blog/client';
+import type {Props} from '@theme/BlogPostItem/Header/Info';
+
+import styles from './styles.module.css';
+
+// Very simple pluralization: probably good enough for now
+function useReadingTimePlural() {
+  const {selectMessage} = usePluralForm();
+  return (readingTimeFloat: number) => {
+    const readingTime = Math.ceil(readingTimeFloat);
+    return selectMessage(
+      readingTime,
+      translate(
+        {
+          id: 'theme.blog.post.readingTime.plurals',
+          description:
+            'Pluralized label for "{readingTime} min read". Use as much plural forms (separated by "|") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)',
+          message: 'One min read|{readingTime} min read',
+        },
+        {readingTime},
+      ),
+    );
+  };
+}
+
+function ReadingTime({readingTime}: {readingTime: number}) {
+  const readingTimePlural = useReadingTimePlural();
+  return <>{readingTimePlural(readingTime)}</>;
+}
+
+function DateTime({
+  date,
+  formattedDate,
+}: {
+  date: string;
+  formattedDate: string;
+}) {
+  return <time dateTime={date}>{formattedDate}</time>;
+}
+
+function Spacer() {
+  return <>{' · '}</>;
+}
+
+export default function BlogPostItemHeaderInfo({className}: Props): ReactNode {
+  const {metadata} = useBlogPost();
+  const {date, readingTime} = metadata;
+  const isThought = metadata.permalink.startsWith('/thoughts');
+
+  const dateTimeFormat = useDateTimeFormat({
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+
+  const dateTimeFormatWhenIsThought = useDateTimeFormat({
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric'
+  });
+
+  const formatDate = (blogDate: string) => {
+      return isThought
+        ? dateTimeFormatWhenIsThought.format(new Date(blogDate))
+        : dateTimeFormat.format(new Date(blogDate));
+    }
+
+  return (
+    <div className={clsx(styles.container, 'margin-vert--md', className)}>
+      <DateTime date={date} formattedDate={formatDate(date)} />
+      {typeof readingTime !== 'undefined' && (
+        <>
+          <Spacer />
+          <ReadingTime readingTime={readingTime} />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/theme/BlogPostItem/Header/Info/styles.module.css
+++ b/src/theme/BlogPostItem/Header/Info/styles.module.css
@@ -1,0 +1,3 @@
+.container {
+  font-size: 0.9rem;
+}

--- a/src/theme/BlogPostItem/Header/Title/index.tsx
+++ b/src/theme/BlogPostItem/Header/Title/index.tsx
@@ -1,0 +1,22 @@
+import React, {type ReactNode} from 'react';
+import Title from '@theme-original/BlogPostItem/Header/Title';
+import type TitleType from '@theme/BlogPostItem/Header/Title';
+import type {WrapperProps} from '@docusaurus/types';
+import { useBlogPost } from '@docusaurus/plugin-content-blog/client';
+import styles from './styles.module.css';
+import clsx from 'clsx'
+
+type Props = WrapperProps<typeof TitleType>;
+
+export default function TitleWrapper(props: Props): ReactNode {
+  const {metadata} = useBlogPost();
+  const isThought = metadata.permalink.startsWith('/thoughts');
+  return (
+    <>
+      <Title
+        {...props}
+        className={clsx(props.className, isThought && styles.thoughtTitle)}
+      />
+    </>
+  );
+}

--- a/src/theme/BlogPostItem/Header/Title/styles.module.css
+++ b/src/theme/BlogPostItem/Header/Title/styles.module.css
@@ -1,0 +1,5 @@
+.thoughtTitle {
+    font-size: 1.5rem;
+    text-decoration: underline;
+    margin-bottom: 0.1rem;
+}

--- a/src/theme/BlogPostItem/Header/index.tsx
+++ b/src/theme/BlogPostItem/Header/index.tsx
@@ -1,0 +1,17 @@
+import React, {type ReactNode} from 'react';
+import BlogPostItemHeaderTitle from '@theme/BlogPostItem/Header/Title';
+import BlogPostItemHeaderInfo from '@theme/BlogPostItem/Header/Info';
+import BlogPostItemHeaderAuthors from '@theme/BlogPostItem/Header/Authors';
+import { useBlogPost } from '@docusaurus/plugin-content-blog/client';
+
+export default function BlogPostItemHeader(): ReactNode {
+  const {metadata} = useBlogPost();
+  const isThought = metadata.permalink.startsWith('/thoughts');
+  return (
+    <header>
+      <BlogPostItemHeaderTitle />
+      {!isThought && <BlogPostItemHeaderInfo />}
+      <BlogPostItemHeaderAuthors />
+    </header>
+  );
+}

--- a/thoughts/2026-08-19-test-thought/2026-08-19-test-thought.md
+++ b/thoughts/2026-08-19-test-thought/2026-08-19-test-thought.md
@@ -1,0 +1,4 @@
+---
+date: 2026-08-19T18:53
+---
+This is a test post for the thoughts "blog" thing.

--- a/thoughts/2026-08-19-test-thought/2026-08-19-test-thought.md
+++ b/thoughts/2026-08-19-test-thought/2026-08-19-test-thought.md
@@ -1,4 +1,0 @@
----
-date: 2026-08-19T18:53
----
-This is a test post for the thoughts "blog" thing.


### PR DESCRIPTION
Added a new instance of the blog plugin with lots of customizations. The focus for this blog is lower-effort, higher-frequency, less-polished bloggy posts, about a wider variety of topics. I want to post more often without compromising the bar for quality that I have for my actual blog.

The Thoughts blog is intended as more of a scrollable feed of shorter posts. I'll be avoiding truncation for these posts so you don't have to click into them to read the whole thing. The post feed has most of the same info from the normal blog plugin, but laid out in a slightly more compact way. Titles for posts will probably just be kebab-case. The thoughts themselves live in a submodule like my blog drafts do. https://github.com/IAmKelDev/keldev-thoughts-drafts

I may continue to tinker with the styling/layout/etc but this is good enough for now. Was a fun exposure to swizzling. So much swizzling.