### PR TITLE
Mobile thoughts now take more screen width

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -171,5 +171,13 @@ ol {
   .mobile-only {
     display: block;
   }
+
+  html.plugin-id-thoughts .main-wrapper {
+    padding: 0.5rem;
+  }
+
+  html.plugin-id-thoughts {
+    --ifm-spacing-horizontal: 0.1rem;
+  }
 }
 


### PR DESCRIPTION
The new Thoughts were harder to read on mobile because they got squished by lots of stacked padding values on intermediate components. Made some adjustments in custom css that are scoped to the Thoughts instance of the blog plugin specifically. Should be more readable.